### PR TITLE
fix: make country search input single-line so Enter confirms instead of newline

### DIFF
--- a/app/src/main/java/app/podiumpodcasts/podium/ui/dialog/CountryCodeSelectorDialog.kt
+++ b/app/src/main/java/app/podiumpodcasts/podium/ui/dialog/CountryCodeSelectorDialog.kt
@@ -68,6 +68,7 @@ fun CountryCodeSelectorDialog(
                 modifier = Modifier
                     .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
                     .fillMaxWidth(),
+                singleLine = true,
 
                 leadingIcon = {
                     Icon(Icons.Rounded.Search, stringResource(R.string.common_search))


### PR DESCRIPTION
- Add `singleLine = true` to the country selector's search to prevent entering newline when pressing enter confirm